### PR TITLE
Better beacons, Prevented crashing on invalid upgrade, /restart_run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,6 @@ dependencies {
 
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-
-    include modImplementation("com.github.0x3C50:Renderer:e1bb03f45e")
 }
 
 processResources {

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/FruitfulUtilities.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/FruitfulUtilities.java
@@ -53,6 +53,13 @@ public class FruitfulUtilities implements ClientModInitializer {
 
         ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> {
             dispatcher.register(
+                    ClientCommandManager.literal("restart_run")
+                            .executes(context -> {
+                                context.getSource().sendFeedback(Text.of("§aRestarted run."));
+                                restartRun();
+                                return 1;
+                            }));
+            dispatcher.register(
                     ClientCommandManager.literal("reload_paths")
                             .executes(context -> {
                                 context.getSource().sendFeedback(Text.of("§aReloading paths..."));

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/FruitfulUtilities.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/FruitfulUtilities.java
@@ -9,7 +9,6 @@ import dev.kingrabbit.fruitfulutilities.listener.TickListener;
 import dev.kingrabbit.fruitfulutilities.listener.WorldRenderListener;
 import dev.kingrabbit.fruitfulutilities.pathviewer.PathManager;
 import dev.kingrabbit.fruitfulutilities.pathviewer.PathScreen;
-import me.x150.renderer.event.RenderEvents;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -50,7 +49,6 @@ public class FruitfulUtilities implements ClientModInitializer {
 
         ClientTickEvents.END_CLIENT_TICK.register(new TickListener());
         WorldRenderEvents.END.register(new WorldRenderListener());
-        RenderEvents.WORLD.register(new WorldRenderListener());
         HudRenderCallback.EVENT.register(new HudRenderer());
 
         ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> {

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/config/ConfigManager.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/config/ConfigManager.java
@@ -32,7 +32,7 @@ public class ConfigManager {
         categoryMap = new HashMap<>();
 
         for (Class<? extends ConfigCategory> categoryClass : new Class[]{
-                GeneralCategory.class, GUILocationsCategory.class, PathViewerCategory.class, CodeHiderCategory.class, SearchingTrackerCategory.class, MessageHiderCategory.class, AuctionTimerCategory.class
+                GeneralCategory.class, GUILocationsCategory.class, PathViewerCategory.class, UpgradeBeaconCategory.class, CodeHiderCategory.class, SearchingTrackerCategory.class, MessageHiderCategory.class, AuctionTimerCategory.class
         }) {
 
             try {

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/config/categories/UpgradeBeaconCategory.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/config/categories/UpgradeBeaconCategory.java
@@ -1,0 +1,16 @@
+package dev.kingrabbit.fruitfulutilities.config.categories;
+
+import dev.kingrabbit.fruitfulutilities.config.CategoryInfo;
+import dev.kingrabbit.fruitfulutilities.config.ConfigCategory;
+import dev.kingrabbit.fruitfulutilities.config.properties.ConfigBoolean;
+
+@CategoryInfo(id = "upgrade_beacons", display = "Upgrade Beacons")
+public class UpgradeBeaconCategory extends ConfigCategory {
+
+    @ConfigBoolean(id = "highlight", display = "Highlight Tracked Upgrades", description = "Places a highlight around all tracked upgrades, visible through all other blocks.")
+    public boolean highlight = true;
+
+    @ConfigBoolean(id = "beacon", display = "Upgrade Beacons", description = "Renders a beacon on all tracked upgrades, disappearing if you move into range.")
+    public boolean beacon = true;
+
+}

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
@@ -36,10 +36,12 @@ public class WorldRenderListener implements WorldRenderEvents.End {
             double distance = playerPos.distanceTo(upgradePos);
             int alpha = (int) Math.min(Math.max(Math.pow(2, 0.5 * distance) * 5, 50), 255);
 
+            Vec3d offset = upgradePos.subtract(MinecraftClient.getInstance().gameRenderer.getCamera().getPos());
+
             MatrixStack matrices = context.matrixStack();
             if (distance >= 5) {
                 matrices.push();
-                matrices.translate(x - playerPos.x, y - playerPos.y - 0.7, z - playerPos.z);
+                matrices.translate(offset.x, offset.y, offset.z);
                 RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, alpha / 255f);
                 BeaconBlockEntityRenderer.renderBeam(
                         matrices,

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
@@ -3,10 +3,7 @@ package dev.kingrabbit.fruitfulutilities.listener;
 import com.google.gson.JsonObject;
 import com.mojang.blaze3d.systems.RenderSystem;
 import dev.kingrabbit.fruitfulutilities.FruitfulUtilities;
-import dev.kingrabbit.fruitfulutilities.config.categories.PathViewerCategory;
 import dev.kingrabbit.fruitfulutilities.pathviewer.PathManager;
-import me.x150.renderer.event.RenderEvents;
-import me.x150.renderer.render.Renderer3d;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.minecraft.client.MinecraftClient;
@@ -18,33 +15,8 @@ import java.awt.*;
 import java.util.Objects;
 import java.util.logging.Logger;
 
-public class WorldRenderListener implements RenderEvents.RenderEvent, WorldRenderEvents.End {
+public class WorldRenderListener implements WorldRenderEvents.End {
 
-    @SuppressWarnings("DuplicatedCode")
-    @Override
-    public void rendered(MatrixStack matrices) {
-        if (MinecraftClient.getInstance().player == null) return;
-        if (!FruitfulUtilities.getInstance().configManager.enabled()) return;
-        
-        for (JsonObject upgrade : PathManager.allTracked()) {
-
-            String[] location = upgrade.get("location").getAsString().split(",");
-            if (location.length != 3)
-                Logger.getGlobal().severe("Unable to parse location of " + upgrade.get("display").getAsString() + " (" + upgrade.get("location").getAsString() + ")");
-            int x = Integer.parseInt(location[0]);
-            int y = Integer.parseInt(location[1]);
-            int z = Integer.parseInt(location[2]);
-
-            Renderer3d.renderThroughWalls();
-            Vec3d upgradePos = new Vec3d(x, y, z);
-            double distance = MinecraftClient.getInstance().player.getPos().distanceTo(upgradePos);
-            int alpha = (int) Math.min(Math.max(Math.pow(2, 0.5 * distance) * 5, 50), 255);
-            Renderer3d.renderFilled(matrices, new Color(140, 0, 250, alpha), upgradePos, new Vec3d(1, 1, 1));
-            Renderer3d.stopRenderThroughWalls();
-        }
-    }
-
-    @SuppressWarnings("DuplicatedCode")
     @Override
     public void onEnd(WorldRenderContext context) {
         if (MinecraftClient.getInstance().player == null) return;

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
@@ -23,7 +23,6 @@ public class WorldRenderListener implements WorldRenderEvents.End {
         if (MinecraftClient.getInstance().player == null) return;
         if (!FruitfulUtilities.getInstance().configManager.enabled()) return;
 
-        Vec3d playerPos = MinecraftClient.getInstance().player.getPos();
         for (JsonObject upgrade : PathManager.allTracked()) {
 
             String[] location = upgrade.get("location").getAsString().split(",");

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
@@ -37,9 +37,10 @@ public class WorldRenderListener implements WorldRenderEvents.End {
             Vec3d upgradePos = new Vec3d(rawX, rawY, rawZ);
             MatrixStack matrices = context.matrixStack();
             Matrix4f matrix = matrices.peek().getPositionMatrix();
-            Vec3d offset = upgradePos.subtract(MinecraftClient.getInstance().gameRenderer.getCamera().getPos());
+            Vec3d cameraPos = MinecraftClient.getInstance().gameRenderer.getCamera().getPos();
+            Vec3d offset = upgradePos.subtract(cameraPos);
 
-            double distance = playerPos.distanceTo(upgradePos);
+            double distance = cameraPos.distanceTo(upgradePos);
             float red = 140 / 255f;
             float green = 0f;
             float blue = 250 / 255f;

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
@@ -35,12 +35,13 @@ public class WorldRenderListener implements WorldRenderEvents.End {
             Vec3d upgradePos = new Vec3d(x, y, z);
             double distance = playerPos.distanceTo(upgradePos);
             int alpha = (int) Math.min(Math.max(Math.pow(2, 0.5 * distance) * 5, 50), 255);
+
+            MatrixStack matrices = context.matrixStack();
             if (distance >= 5) {
-                context.matrixStack().push();
-                context.matrixStack().translate(x - playerPos.x, y - playerPos.y - 0.7, z - playerPos.z);
-                RenderSystem.setShaderColor(140, 0, 250, alpha);
+                matrices.push();
+                matrices.translate(x - playerPos.x, y - playerPos.y - 0.7, z - playerPos.z);
                 BeaconBlockEntityRenderer.renderBeam(
-                        context.matrixStack(),
+                        matrices,
                         Objects.requireNonNull(context.consumers()),
                         BeaconBlockEntityRenderer.BEAM_TEXTURE,
                         context.tickDelta(),
@@ -52,7 +53,7 @@ public class WorldRenderListener implements WorldRenderEvents.End {
                         0.2f,
                         0f
                 );
-                context.matrixStack().pop();
+                matrices.pop();
             }
         }
     }

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
@@ -40,6 +40,7 @@ public class WorldRenderListener implements WorldRenderEvents.End {
             if (distance >= 5) {
                 matrices.push();
                 matrices.translate(x - playerPos.x, y - playerPos.y - 0.7, z - playerPos.z);
+                RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, alpha / 255f);
                 BeaconBlockEntityRenderer.renderBeam(
                         matrices,
                         Objects.requireNonNull(context.consumers()),
@@ -49,7 +50,7 @@ public class WorldRenderListener implements WorldRenderEvents.End {
                         context.world().getTime(),
                         0,
                         255,
-                        new float[]{255, 255, 255},
+                        new float[]{140 / 255f, 0 / 255f, 250 / 255f},
                         0.2f,
                         0f
                 );

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
@@ -28,9 +28,12 @@ public class WorldRenderListener implements WorldRenderEvents.End {
             String[] location = upgrade.get("location").getAsString().split(",");
             if (location.length != 3)
                 Logger.getGlobal().severe("Unable to parse location of " + upgrade.get("display").getAsString() + " (" + upgrade.get("location").getAsString() + ")");
-            int x = Integer.parseInt(location[0]);
-            int y = Integer.parseInt(location[1]);
-            int z = Integer.parseInt(location[2]);
+            int x1 = Integer.parseInt(location[0]);
+            int y1 = Integer.parseInt(location[1]);
+            int z1 = Integer.parseInt(location[2]);
+            int x2 = x1 + 1;
+            int y2 = y1 + 1;
+            int z2 = z1 + 1;
 
             Vec3d upgradePos = new Vec3d(x, y, z);
             double distance = playerPos.distanceTo(upgradePos);

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
@@ -7,11 +7,12 @@ import dev.kingrabbit.fruitfulutilities.pathviewer.PathManager;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.*;
 import net.minecraft.client.render.block.entity.BeaconBlockEntityRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.Vec3d;
+import org.joml.Matrix4f;
 
-import java.awt.*;
 import java.util.Objects;
 import java.util.logging.Logger;
 
@@ -28,24 +29,80 @@ public class WorldRenderListener implements WorldRenderEvents.End {
             String[] location = upgrade.get("location").getAsString().split(",");
             if (location.length != 3)
                 Logger.getGlobal().severe("Unable to parse location of " + upgrade.get("display").getAsString() + " (" + upgrade.get("location").getAsString() + ")");
-            int x1 = Integer.parseInt(location[0]);
-            int y1 = Integer.parseInt(location[1]);
-            int z1 = Integer.parseInt(location[2]);
-            int x2 = x1 + 1;
-            int y2 = y1 + 1;
-            int z2 = z1 + 1;
 
-            Vec3d upgradePos = new Vec3d(x, y, z);
-            double distance = playerPos.distanceTo(upgradePos);
-            int alpha = (int) Math.min(Math.max(Math.pow(2, 0.5 * distance) * 5, 50), 255);
+            int rawX = Integer.parseInt(location[0]);
+            int rawY = Integer.parseInt(location[1]);
+            int rawZ = Integer.parseInt(location[2]);
 
+            Vec3d upgradePos = new Vec3d(rawX, rawY, rawZ);
+            MatrixStack matrices = context.matrixStack();
+            Matrix4f matrix = matrices.peek().getPositionMatrix();
             Vec3d offset = upgradePos.subtract(MinecraftClient.getInstance().gameRenderer.getCamera().getPos());
 
-            MatrixStack matrices = context.matrixStack();
+            double distance = playerPos.distanceTo(upgradePos);
+            float red = 140 / 255f;
+            float green = 0f;
+            float blue = 250 / 255f;
+            float alpha = ((int) Math.min(Math.max(Math.pow(2, 0.5 * distance) * 5, 50), 255)) / 255f;
+
+            if (true) {
+                float x1, x2, y1, y2, z1, z2;
+                x1 = x2 = (float) offset.x;
+                y1 = y2 = (float) offset.y;
+                z1 = z2 = (float) offset.z;
+                x2++;
+                y2++;
+                z2++;
+
+                RenderSystem.enableBlend();
+                RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+                RenderSystem.disableDepthTest();
+                RenderSystem.setShader(GameRenderer::getPositionColorProgram);
+
+                Tessellator tessellator = Tessellator.getInstance();
+                BufferBuilder buffer = tessellator.getBuffer();
+
+                buffer.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
+                buffer.vertex(matrix, x1, y2, z1).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x1, y2, z2).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y2, z2).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y2, z1).color(red, green, blue, alpha).next();
+
+                buffer.vertex(matrix, x1, y1, z2).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y1, z2).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y2, z2).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x1, y2, z2).color(red, green, blue, alpha).next();
+
+                buffer.vertex(matrix, x2, y2, z2).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y1, z2).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y1, z1).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y2, z1).color(red, green, blue, alpha).next();
+
+                buffer.vertex(matrix, x2, y2, z1).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y1, z1).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x1, y1, z1).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x1, y2, z1).color(red, green, blue, alpha).next();
+
+                buffer.vertex(matrix, x1, y2, z1).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x1, y1, z1).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x1, y1, z2).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x1, y2, z2).color(red, green, blue, alpha).next();
+
+                buffer.vertex(matrix, x1, y1, z1).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y1, z1).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x2, y1, z2).color(red, green, blue, alpha).next();
+                buffer.vertex(matrix, x1, y1, z2).color(red, green, blue, alpha).next();
+
+                BufferRenderer.drawWithGlobalProgram(buffer.end());
+
+                RenderSystem.enableCull();
+                RenderSystem.disableBlend();
+                RenderSystem.enableDepthTest();
+            }
+
             if (distance >= 5) {
                 matrices.push();
-                matrices.translate(offset.x, offset.y, offset.z);
-                RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, alpha / 255f);
+                matrices.translate(offset.x, offset.y + 1, offset.z);
                 BeaconBlockEntityRenderer.renderBeam(
                         matrices,
                         Objects.requireNonNull(context.consumers()),
@@ -55,7 +112,7 @@ public class WorldRenderListener implements WorldRenderEvents.End {
                         context.world().getTime(),
                         0,
                         255,
-                        new float[]{140 / 255f, 0 / 255f, 250 / 255f},
+                        new float[]{red, green, blue},
                         0.2f,
                         0f
                 );

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/WorldRenderListener.java
@@ -3,6 +3,8 @@ package dev.kingrabbit.fruitfulutilities.listener;
 import com.google.gson.JsonObject;
 import com.mojang.blaze3d.systems.RenderSystem;
 import dev.kingrabbit.fruitfulutilities.FruitfulUtilities;
+import dev.kingrabbit.fruitfulutilities.config.ConfigManager;
+import dev.kingrabbit.fruitfulutilities.config.categories.UpgradeBeaconCategory;
 import dev.kingrabbit.fruitfulutilities.pathviewer.PathManager;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
@@ -21,7 +23,12 @@ public class WorldRenderListener implements WorldRenderEvents.End {
     @Override
     public void onEnd(WorldRenderContext context) {
         if (MinecraftClient.getInstance().player == null) return;
-        if (!FruitfulUtilities.getInstance().configManager.enabled()) return;
+
+        ConfigManager configManager = FruitfulUtilities.getInstance().configManager;
+        if (!configManager.enabled()) return;
+
+        UpgradeBeaconCategory category = configManager.getCategory(UpgradeBeaconCategory.class);
+        if (!(category.highlight || category.beacon)) return;
 
         for (JsonObject upgrade : PathManager.allTracked()) {
 
@@ -45,7 +52,7 @@ public class WorldRenderListener implements WorldRenderEvents.End {
             float blue = 250 / 255f;
             float alpha = ((int) Math.min(Math.max(Math.pow(2, 0.5 * distance) * 5, 50), 255)) / 255f;
 
-            if (true) {
+            if (category.highlight) {
                 float x1, x2, y1, y2, z1, z2;
                 x1 = x2 = (float) offset.x;
                 y1 = y2 = (float) offset.y;
@@ -100,7 +107,7 @@ public class WorldRenderListener implements WorldRenderEvents.End {
                 RenderSystem.enableDepthTest();
             }
 
-            if (distance >= 5) {
+            if (category.beacon && distance >= 5) {
                 matrices.push();
                 matrices.translate(offset.x, offset.y + 1, offset.z);
                 BeaconBlockEntityRenderer.renderBeam(

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java
@@ -555,6 +555,11 @@ public class PathScreen extends Screen {
     }
 
     public void renderUpgrade(MatrixStack matrices, JsonObject upgrade, float x, float y, int mouseX, int mouseY) {
+        if (upgrade == null) {
+            FruitfulUtilities.LOGGER.error("Not rendering upgrade at " + x + ", " + y + " on path " + section + " as it is null.");
+            return;
+        }
+
         float _xOffset = xOffset();
         float _yOffset = yOffset();
         float _zoom = zoom();

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java
@@ -50,6 +50,7 @@ public class PathScreen extends Screen {
     public static HashMap<String, JsonObject> selectedElement = new HashMap<>();
 
     public final HashMap<Region, JsonObject> drawnElements = new HashMap<>();
+    public final List<String> sentErrors = new ArrayList<>();
     public List<OrderedText> tooltip = null;
 
     public PathScreen() {
@@ -556,7 +557,11 @@ public class PathScreen extends Screen {
 
     public void renderUpgrade(MatrixStack matrices, JsonObject upgrade, float x, float y, int mouseX, int mouseY) {
         if (upgrade == null) {
-            FruitfulUtilities.LOGGER.error("Not rendering upgrade at " + x + ", " + y + " on path " + section + " as it is null.");
+            String errorMessage = "Not rendering upgrade at " + x + ", " + y + " on path " + section + " as it is null.";
+            if (!sentErrors.contains(errorMessage)) {
+                sentErrors.add(errorMessage);
+                FruitfulUtilities.LOGGER.error(errorMessage);
+            }
             return;
         }
 


### PR DESCRIPTION
- Beacons now move smoothly
- Smoother alpha transition
- Users can now disable beacons and highlights
- No longer using an external library
- Game no longer crashes if it can't find an upgrade
- Users can now use /restart_run to manually restart