### PR TITLE
Added Auction Alerts

### DIFF
--- a/src/main/java/dev/kingrabbit/fruitfulutilities/config/categories/AuctionTimerCategory.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/config/categories/AuctionTimerCategory.java
@@ -11,4 +11,11 @@ public class AuctionTimerCategory extends ConfigCategory {
     @ConfigBoolean(id = "enabled", display = "Enable Timer", description = "Enables the Auction Timer, appearing on your HUD.")
     public boolean enabled = true;
 
+    @ConfigBoolean(id = "alert", display = "Always Send Alert", description = "Always send an alert when auctions start, even if disabled on Melon King.")
+    public boolean alert = true;
+
+
+    @ConfigBoolean(id = "warning", display = "Always Send Warning", description = "Always send a warning when auctions start, even if disabled on Melon King.")
+    public boolean warning = true;
+
 }

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/config/categories/AuctionTimerCategory.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/config/categories/AuctionTimerCategory.java
@@ -15,7 +15,7 @@ public class AuctionTimerCategory extends ConfigCategory {
     public boolean alert = true;
 
 
-    @ConfigBoolean(id = "warning", display = "Always Send Warning", description = "Always send a warning when auctions start, even if disabled on Melon King.")
+    @ConfigBoolean(id = "warning", display = "Always Send Warning", description = "Always send a warning 60 seconds before auctions start, even if disabled on Melon King.")
     public boolean warning = true;
 
 }

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/hud/elements/AuctionTimerElement.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/hud/elements/AuctionTimerElement.java
@@ -25,8 +25,14 @@ public class AuctionTimerElement extends HudElement {
     public List<Object> render(float tickDelta) {
         if (!FruitfulUtilities.getInstance().configManager.getCategory(AuctionTimerCategory.class).enabled) return Collections.emptyList();
 
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        int[] timeUntilAuctions = getTimeUntilAuctions();
+        int minutesRemaining = timeUntilAuctions[0], secondsRemaining = timeUntilAuctions[1];
 
+        return Collections.singletonList("§6Auction Timer: §e" + (minutesRemaining < 10 ? "0" : "") + minutesRemaining + ":" + (secondsRemaining < 10 ? "0" : "") + secondsRemaining);
+    }
+
+    public static int[] getTimeUntilAuctions() {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
         int currentMinute = calendar.get(Calendar.MINUTE);
         int currentSecond = calendar.get(Calendar.SECOND);
 
@@ -37,7 +43,7 @@ public class AuctionTimerElement extends HudElement {
             secondsRemaining = 0;
         }
 
-        return Collections.singletonList("§6Auction Timer: §e" + (minutesRemaining < 10 ? "0" : "") + minutesRemaining + ":" + (secondsRemaining < 10 ? "0" : "") + secondsRemaining);
+        return new int[]{minutesRemaining, secondsRemaining};
     }
 
 }

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
@@ -88,6 +88,7 @@ public class TickListener implements ClientTickEvents.EndTick {
                 if (auctionTimerCategory.warning && !auctionWarningReceived) {
                     auctionWarningReceived = true;
                     client.player.sendMessage(Text.of("§8» §7A set of auctions is starting in 60 seconds!"));
+                    client.player.playSound(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 2.0f, 1.0f);
                 }
                 sendAuctionAlertAt = tick + secondsRemaining * 20;
             } else if (auctionWarningReceived || auctionAlertReceived) {

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
@@ -4,12 +4,15 @@ import dev.kingrabbit.fruitfulutilities.FruitfulUtilities;
 import dev.kingrabbit.fruitfulutilities.Keybinds;
 import dev.kingrabbit.fruitfulutilities.config.ConfigManager;
 import dev.kingrabbit.fruitfulutilities.config.ConfigScreen;
+import dev.kingrabbit.fruitfulutilities.config.categories.AuctionTimerCategory;
 import dev.kingrabbit.fruitfulutilities.config.categories.SearchingTrackerCategory;
+import dev.kingrabbit.fruitfulutilities.hud.elements.AuctionTimerElement;
 import dev.kingrabbit.fruitfulutilities.pathviewer.PathManager;
 import dev.kingrabbit.fruitfulutilities.pathviewer.PathScreen;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
@@ -23,6 +26,10 @@ public class TickListener implements ClientTickEvents.EndTick {
     public static int tick = 0;
     public static int searchingUntil = 0;
     public static int testUndergroundAt = -1;
+
+    public static boolean auctionWarningReceived = false;
+    public static boolean auctionAlertReceived = false;
+    public static int sendAuctionAlertAt = -1;
 
     @Override
     public void onEndTick(MinecraftClient client) {
@@ -60,6 +67,32 @@ public class TickListener implements ClientTickEvents.EndTick {
                         PathManager.purchasedIds.add("upgrade_town_second_wall");
                     }
                 }
+            }
+        }
+
+        if (client.player != null) {
+            AuctionTimerCategory auctionTimerCategory = configManager.getCategory(AuctionTimerCategory.class);
+
+            if (tick >= sendAuctionAlertAt && sendAuctionAlertAt != -1) {
+                if (auctionTimerCategory.alert && !auctionAlertReceived) {
+                    auctionAlertReceived = true;
+                    client.player.sendMessage(Text.of("§8» §7A set of auctions is starting!"));
+                    client.player.playSound(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 2.0f, 1.0f);
+                }
+                sendAuctionAlertAt = -1;
+            }
+
+            int[] timeUntilAuctions = AuctionTimerElement.getTimeUntilAuctions();
+            int minutesRemaining = timeUntilAuctions[0], secondsRemaining = timeUntilAuctions[1] + 1;
+            if (minutesRemaining == 0 && secondsRemaining <= 59) {
+                if (auctionTimerCategory.warning && !auctionWarningReceived) {
+                    auctionWarningReceived = true;
+                    client.player.sendMessage(Text.of("§8» §7A set of auctions is starting in 60 seconds!"));
+                }
+                sendAuctionAlertAt = tick + secondsRemaining * 20;
+            } else if (auctionWarningReceived || auctionAlertReceived) {
+                auctionWarningReceived = false;
+                auctionAlertReceived = false;
             }
         }
 

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/mixin/ClientPlayNetworkHandlerMixin.java
@@ -64,6 +64,11 @@ public abstract class ClientPlayNetworkHandlerMixin {
             }
         }
 
+        if (message.equals("» A set of auctions is starting!"))
+            TickListener.auctionAlertReceived = true;
+        else if (message.equals("» A set of auctions is starting in 60 seconds!"))
+            TickListener.auctionWarningReceived = true;
+
         if (message.matches("^> The (king|queen|monarch|city) has purchased the (.*) (major upgrade|upgrade|renovation)( for [0-9]{1,16} .*)?\\.$")) {
             Matcher matcher = UPGRADE_PURCHASED_PATTERN.matcher(message);
             while (matcher.find()) {


### PR DESCRIPTION
Gives the user an option to receive a warning and/or an alert for auctions by default.  
They are only sent if the corresponding message isn't detected from Melon King.
![image](https://github.com/KingsMMA/FruitfulUtilities/assets/63374258/3655f831-6ac1-4fe9-a70b-37999859568b)
![image](https://github.com/KingsMMA/FruitfulUtilities/assets/63374258/4bb48fab-c2d0-4b05-be28-e35067748cc4)
