### PR TITLE
Updated to 1.20.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,10 @@ All contributions are greatly appreciated.
 <b>6.</b> Follow the steps in the [previous section](https://github.com/KingsMMA/FruitfulUtilities/blob/master/CONTRIBUTING.md#contributing-to-the-mod) to begin contributing the changes to the mod.  
 
 ### If you added a new path
-<b>1.</b> Load the path in [`PathManager#loadPaths()`](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathManager.java#L33).  
-<b>2.</b> Save its parent paths in [`PathManager#`](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathManager.java#L24).  
-<b>3.</b> Create the icon in [`PathScreen#init()`](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java#L59).  
-<b>4.</b> Add a branch to the if statement beginning [here](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java#L94) in `PathScreen#init()`.  
+<b>1.</b> Load the path in [`PathManager#loadPaths()`](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathManager.java#L44).  
+<b>2.</b> Save its parent paths in [`PathManager#`](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathManager.java#L31).  
+<b>3.</b> Create the icon in [`PathScreen#init()`](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java#L63).  
+<b>4.</b> Add a branch to the if statement beginning [here](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java#L107) in `PathScreen#init()`.  
 ```java
 else if (section.equals("<path_id>")) {
     JsonObject <path_id> = PathManager.paths.get("<path_id>");
@@ -28,7 +28,7 @@ else if (section.equals("<path_id>")) {
 <b>5.</b> Next, add the upgrades as described below:
 
 ### If you added a new upgrade
-<b>1.</b> Render the upgrade in the appropriate branch of [`PathScreen#init()`](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java#L94).  
+<b>1.</b> Render the upgrade in the appropriate branch of [`PathScreen#init()`](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java#L107).  
 ```java
 renderUpgrade(matrices, <path_id>.getAsJsonObject("<upgrade_id>"), <gridX>, <gridY>, mouseX, mouseY);
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ After making any changes, build the project by clicking `Build > Build Project` 
 
 ### Hotswapping Mixins
 Mixins can't be hotswapped in a default FabricMC environment.  
-For more information, see [here](https://fabricmc.net/wiki/tutorial:mixin_hotswaps).
+To update your Run Configurations for hotswapping mixins, see [here](https://fabricmc.net/wiki/tutorial:mixin_hotswaps).
 
 ### Limitations
 While hotswaps are a great utility for easily testing changes, there are certain limitations.  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ else if (section.equals("<path_id>")) {
 ### If you added a new upgrade
 <b>1.</b> Render the upgrade in the appropriate branch of [`PathScreen#init()`](https://github.com/KingsMMA/FruitfulUtilities/blob/master/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java#L107).  
 ```java
-renderUpgrade(matrices, <path_id>.getAsJsonObject("<upgrade_id>"), <gridX>, <gridY>, mouseX, mouseY);
+renderUpgrade(context, <path_id>.getAsJsonObject("<upgrade_id>"), <gridX>, <gridY>, mouseX, mouseY);
 ```
 <b>2.</b> If required, connect it to any relevant upgrades as such:
 ```java

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="assets/banner.png" alt="Banner" width=70%/>
 
 FruitfulUtilities is a utility mod for Melon King on the DiamondFire minecraft server.  
-It is a Fabric 1.19.4 mod designed to enhance the user experience and guide newer players on Melon King, containing the following features:
+It is a Fabric 1.20.1 mod designed to enhance the user experience and guide newer players on Melon King, containing the following features:
 - In-depth path viewer
 - Upgrade tracker
 - Searching tracker

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@
                     <svg>
                         <use xlink:href="#icon-80ea30b5b2fef8b399f9b3c4a14e6bee"></use>
                     </svg>
-                    <span class="label">Download (Fabric 1.19.4)</span>
+                    <span class="label">Download (Fabric 1.20.1)</span>
                 </a>
             </li>
             <li>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.19.4
-yarn_mappings=1.19.4+build.2
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.9
 loader_version=0.14.21
 # Mod Properties
 mod_version=1.0.0-RELEASE
@@ -11,4 +11,4 @@ maven_group=dev.kingrabbit
 archives_base_name=fruitfulutilities
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.82.0+1.19.4
+fabric_version=0.85.0+1.20.1

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/config/ConfigScreen.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/config/ConfigScreen.java
@@ -1,6 +1,5 @@
 package dev.kingrabbit.fruitfulutilities.config;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import dev.kingrabbit.fruitfulutilities.FruitfulUtilities;
 import dev.kingrabbit.fruitfulutilities.config.properties.ConfigBoolean;
 import dev.kingrabbit.fruitfulutilities.config.properties.ConfigButton;
@@ -8,7 +7,7 @@ import dev.kingrabbit.fruitfulutilities.config.properties.ConfigDropdown;
 import dev.kingrabbit.fruitfulutilities.pathviewer.PathManager;
 import dev.kingrabbit.fruitfulutilities.util.SoundUtils;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.OrderedText;
@@ -62,27 +61,28 @@ public class ConfigScreen extends Screen {
     }
 
     @Override
-    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
         if (client == null) return;
 
-        renderBackground(matrices);
+        renderBackground(context);
 
         // Background
-        DrawableHelper.fill(matrices, width / 2 - 200 - 4, height / 2 - 150 + 4, width / 2 + 200 - 4, height / 2 + 150 + 4, WINDOW_BACKGROUND_SHADOW);
-        DrawableHelper.fill(matrices, width / 2 - 200, height / 2 - 150, width / 2 + 200, height / 2 + 150, WINDOW_BACKGROUND);
+        context.fill(width / 2 - 200 - 4, height / 2 - 150 + 4, width / 2 + 200 - 4, height / 2 + 150 + 4, WINDOW_BACKGROUND_SHADOW);
+        context.fill(width / 2 - 200, height / 2 - 150, width / 2 + 200, height / 2 + 150, WINDOW_BACKGROUND);
 
         // Header Bevel
-        DrawableHelper.fill(matrices, width / 2 - 200 + 10, height / 2 - 150 + 10, width / 2 + 200 - 10, height / 2 - 150 + 50, HEADER_BACKGROUND_SHADOW);
-        DrawableHelper.fill(matrices, width / 2 - 200 + 10 + 2, height / 2 - 150 + 10 + 2, width / 2 + 200 - 10, height / 2 - 150 + 50, HEADER_BACKGROUND);
+        context.fill(width / 2 - 200 + 10, height / 2 - 150 + 10, width / 2 + 200 - 10, height / 2 - 150 + 50, HEADER_BACKGROUND_SHADOW);
+        context.fill(width / 2 - 200 + 10 + 2, height / 2 - 150 + 10 + 2, width / 2 + 200 - 10, height / 2 - 150 + 50, HEADER_BACKGROUND);
 
+        MatrixStack matrices = context.getMatrices();
         matrices.push();
         matrices.scale(2f, 2f, 2f);
-        DrawableHelper.drawCenteredTextWithShadow(matrices, client.textRenderer, "FruitfulUtilities", (width / 2) / 2, (height / 2 - 150 + 24) / 2, 0xFFFFFF);
+        context.drawCenteredTextWithShadow(client.textRenderer, "FruitfulUtilities", (width / 2) / 2, (height / 2 - 150 + 24) / 2, 0xFFFFFF);
         matrices.pop();
 
         // Categories Bevel
-        DrawableHelper.fill(matrices, width / 2 - 200 + 10, height / 2 - 150 + 60, width / 2 - 200 + 120, height / 2 + 150 - 10, SECTION_BACKGROUND_SHADOW);
-        DrawableHelper.fill(matrices, width / 2 - 200 + 10 + 2, height / 2 - 150 + 60 + 2, width / 2 - 200 + 120, height / 2 + 150 - 10, SECTION_BACKGROUND);
+        context.fill(width / 2 - 200 + 10, height / 2 - 150 + 60, width / 2 - 200 + 120, height / 2 + 150 - 10, SECTION_BACKGROUND_SHADOW);
+        context.fill(width / 2 - 200 + 10 + 2, height / 2 - 150 + 60 + 2, width / 2 - 200 + 120, height / 2 + 150 - 10, SECTION_BACKGROUND);
 
         int x = width / 2 - 200 + 14;
         AtomicInteger y = new AtomicInteger(height / 2 - 150 + 60 + 2);
@@ -93,20 +93,20 @@ public class ConfigScreen extends Screen {
             int x2 = x + 106;
             int y2 = y.get() - 1;
             if (selected_section.equals(categoryInfo.id())) {
-                DrawableHelper.fill(matrices, x1, currentY, x2, y2, new Color(40, 40, 80).getRGB());
+                context.fill(x1, currentY, x2, y2, new Color(40, 40, 80).getRGB());
             }
             if (x1 <= mouseX && mouseX <= x2 &&
                     currentY <= mouseY && mouseY <= y2) {
-                DrawableHelper.fill(matrices, x1, currentY, x2, y2, HOVER_OVERLAY);
+                context.fill(x1, currentY, x2, y2, HOVER_OVERLAY);
             }
 
-            DrawableHelper.drawTextWithShadow(matrices, client.textRenderer, categoryInfo.display(), x + 1, currentY + 3, 0xFFFFFF);
-            DrawableHelper.drawHorizontalLine(matrices, x1, x + 105, y2, SECTION_BACKGROUND_SHADOW);
+            context.drawTextWithShadow(client.textRenderer, categoryInfo.display(), x + 1, currentY + 3, 0xFFFFFF);
+            context.drawHorizontalLine(x1, x + 105, y2, SECTION_BACKGROUND_SHADOW);
         });
 
         // Section Bevel
-        DrawableHelper.fill(matrices, width / 2 - 200 + 130, height / 2 - 150 + 60, width / 2 + 200 - 10, height / 2 + 150 - 10, SECTION_BACKGROUND_SHADOW);
-        DrawableHelper.fill(matrices, width / 2 - 200 + 130 + 2, height / 2 - 150 + 60 + 2, width / 2 + 200 - 10, height / 2 + 150 - 10, SECTION_BACKGROUND);
+        context.fill(width / 2 - 200 + 130, height / 2 - 150 + 60, width / 2 + 200 - 10, height / 2 + 150 - 10, SECTION_BACKGROUND_SHADOW);
+        context.fill(width / 2 - 200 + 130 + 2, height / 2 - 150 + 60 + 2, width / 2 + 200 - 10, height / 2 + 150 - 10, SECTION_BACKGROUND);
 
         ConfigCategory selectedCategory = FruitfulUtilities.getInstance().configManager.categoryIds.get(selected_section);
         Class<? extends ConfigCategory> selectedCategoryClass = selectedCategory.getClass();
@@ -126,7 +126,7 @@ public class ConfigScreen extends Screen {
                 matrices.scale(0.8f, 0.8f, 0.8f);
                 int centerX = (int) ((x1 + (x2 - x1) / 2f) / 0.8);
                 for (OrderedText line : lines) {
-                    DrawableHelper.drawCenteredTextWithShadow(matrices, textRenderer, line, centerX, (int) (propertyY / 0.8f), 0xEF1515);
+                    context.drawCenteredTextWithShadow(textRenderer, line, centerX, (int) (propertyY / 0.8f), 0xEF1515);
                     propertyY += (textRenderer.fontHeight + 2) * 0.8f;
                 }
                 propertyY += (textRenderer.fontHeight + 2) * 0.8f;
@@ -166,17 +166,17 @@ public class ConfigScreen extends Screen {
                     description = configButton.description();
                 }
 
-                DrawableHelper.fill(matrices, x1 + 5, propertyY, x2 - 5, propertyY + 50, SECTION_BACKGROUND_SHADOW);
-                DrawableHelper.fill(matrices, x1 + 5, propertyY, x2 - 5 - 2, propertyY + 50 - 2, OPTION_FOREGROUND);
+                context.fill(x1 + 5, propertyY, x2 - 5, propertyY + 50, SECTION_BACKGROUND_SHADOW);
+                context.fill(x1 + 5, propertyY, x2 - 5 - 2, propertyY + 50 - 2, OPTION_FOREGROUND);
 
-                DrawableHelper.drawTextWithShadow(matrices, client.textRenderer, display, x1 + 8, propertyY + 3, 0xFFFFFF);
+                context.drawTextWithShadow(client.textRenderer, display, x1 + 8, propertyY + 3, 0xFFFFFF);
 
                 matrices.push();
                 matrices.scale(0.8f, 0.8f, 0.8f);
                 List<OrderedText> descriptionLines = textRenderer.wrapLines(StringVisitable.plain(description), 220);
                 int offset = -9;
                 for (OrderedText line : descriptionLines) {
-                    DrawableHelper.drawTextWithShadow(matrices, client.textRenderer, line, (int) ((x1 + 8) / 0.8f), (int) ((propertyY + 14 + (offset += 9)) / 0.8f), DESCRIPTION_TEXT_COLOR);
+                    context.drawTextWithShadow(client.textRenderer, line, (int) ((x1 + 8) / 0.8f), (int) ((propertyY + 14 + (offset += 9)) / 0.8f), DESCRIPTION_TEXT_COLOR);
                 }
                 matrices.pop();
             }
@@ -184,40 +184,42 @@ public class ConfigScreen extends Screen {
             if (isConfigBoolean) {
                 matrices.push();
                 matrices.scale(1.5f, 1.5f, 1.5f);
+
+                Identifier textureId;
                 try {
-                    RenderSystem.setShaderTexture(0, (boolean) field.get(selectedCategory) ? SWITCH_ENABLED : SWITCH_DISABLED);
+                    textureId = (boolean) field.get(selectedCategory) ? SWITCH_ENABLED : SWITCH_DISABLED;
                 } catch (IllegalAccessException exception) {
-                    RenderSystem.setShaderTexture(0, SWITCH_UNKNOWN);
+                    textureId = SWITCH_UNKNOWN;
                     FruitfulUtilities.LOGGER.error("An error occurred accessing the value of " + field.getName() + " in " + selectedCategoryClass.getName(), exception);
                 }
-                DrawableHelper.drawTexture(matrices, (int) ((x2 - 64) / 1.5f), (int) ((propertyY + 10) / 1.5f), 0, 0, 0, 32, 16, 32, 16);
+                context.drawTexture(textureId, (int) ((x2 - 64) / 1.5f), (int) ((propertyY + 10) / 1.5f), 0, 0, 0, 32, 16, 32, 16);
                 matrices.pop();
             } else if (isConfigDropdown) {
-                DrawableHelper.fill(matrices, x2 - 64, propertyY + 13, x2 - 16, propertyY + 31, SECTION_BACKGROUND_SHADOW);
-                DrawableHelper.fill(matrices, x2 - 62, propertyY + 15, x2 - 16, propertyY + 31, SECTION_BACKGROUND);
+                context.fill(x2 - 64, propertyY + 13, x2 - 16, propertyY + 31, SECTION_BACKGROUND_SHADOW);
+                context.fill(x2 - 62, propertyY + 15, x2 - 16, propertyY + 31, SECTION_BACKGROUND);
 
                 try {
                     String selectedOption = configDropdown.options()[(int) field.get(selectedCategory)];
 
-                    DrawableHelper.drawTextWithShadow(matrices, client.textRenderer, selectedOption, x2 - 59, propertyY + 18, 0xFFFFFF);
+                    context.drawTextWithShadow(client.textRenderer, selectedOption, x2 - 59, propertyY + 18, 0xFFFFFF);
                     if (selected_element.equals(configDropdown.id())) {
-                        DrawableHelper.fill(matrices, x2 - 64, propertyY + 31, x2 - 16, propertyY + 31 + (configDropdown.options().length * 16) + 1, SECTION_BACKGROUND_SHADOW);
-                        DrawableHelper.fill(matrices, x2 - 62, propertyY + 31, x2 - 16, propertyY + 31 + (configDropdown.options().length * 16) + 1, SECTION_BACKGROUND);
+                        context.fill(x2 - 64, propertyY + 31, x2 - 16, propertyY + 31 + (configDropdown.options().length * 16) + 1, SECTION_BACKGROUND_SHADOW);
+                        context.fill(x2 - 62, propertyY + 31, x2 - 16, propertyY + 31 + (configDropdown.options().length * 16) + 1, SECTION_BACKGROUND);
 
                         int propertyOptionsY = propertyY + 31;
-                        DrawableHelper.drawHorizontalLine(matrices, x2 - 64, x2 - 17, propertyOptionsY - 1, SECTION_BACKGROUND_SHADOW);
-                        DrawableHelper.drawHorizontalLine(matrices, x2 - 64, x2 - 17, propertyOptionsY, SECTION_BACKGROUND_SHADOW);
+                        context.drawHorizontalLine(x2 - 64, x2 - 17, propertyOptionsY - 1, SECTION_BACKGROUND_SHADOW);
+                        context.drawHorizontalLine(x2 - 64, x2 - 17, propertyOptionsY, SECTION_BACKGROUND_SHADOW);
                         for (String option : configDropdown.options()) {
-                            DrawableHelper.drawTextWithShadow(matrices, client.textRenderer, option, x2 - 59, propertyOptionsY + 4, DESCRIPTION_TEXT_COLOR);
+                            context.drawTextWithShadow(client.textRenderer, option, x2 - 59, propertyOptionsY + 4, DESCRIPTION_TEXT_COLOR);
 
                             if (x2 - 62 <= mouseX && mouseX <= x2 - 16 &&
                                     propertyOptionsY + 1 <= mouseY && mouseY <= propertyOptionsY + 15) {
-                                DrawableHelper.fill(matrices, x2 - 62, propertyOptionsY + 1, x2 - 16, propertyOptionsY + 15, HOVER_OVERLAY);
+                                context.fill(x2 - 62, propertyOptionsY + 1, x2 - 16, propertyOptionsY + 15, HOVER_OVERLAY);
                             }
 
                             propertyOptionsY += 16;
-                            DrawableHelper.drawHorizontalLine(matrices, x2 - 62, x2 - 17, propertyOptionsY - 1, DROP_OPTION_SEPARATOR);
-                            DrawableHelper.drawHorizontalLine(matrices, x2 - 62, x2 - 17, propertyOptionsY, DROP_OPTION_SEPARATOR);
+                            context.drawHorizontalLine(x2 - 62, x2 - 17, propertyOptionsY - 1, DROP_OPTION_SEPARATOR);
+                            context.drawHorizontalLine(x2 - 62, x2 - 17, propertyOptionsY, DROP_OPTION_SEPARATOR);
                         }
                     }
                 } catch (IllegalAccessException e) {
@@ -226,18 +228,17 @@ public class ConfigScreen extends Screen {
             } else if (isConfigButton) {
                 matrices.push();
                 matrices.scale(2.5f, 2.5f, 2.5f);
-                RenderSystem.setShaderTexture(0, BUTTON);
-                DrawableHelper.drawTexture(matrices, (int) ((x2 - 92) / 2.5f), (int) ((propertyY + 5) / 2.5f), 0, 0, 0, 32, 16, 32, 16);
+                context.drawTexture(BUTTON, (int) ((x2 - 92) / 2.5f), (int) ((propertyY + 5) / 2.5f), 0, 0, 0, 32, 16, 32, 16);
                 matrices.pop();
                 matrices.push();
                 matrices.scale(1.5f, 1.5f, 1.5f);
-                textRenderer.drawWithShadow(matrices, configButton.buttonText(), ((x2 - 92 + 32 - textRenderer.getWidth(configButton.buttonText()) / 2f) / 1.5f), ((propertyY + 16) / 1.5f), 0xFFFFFF);
+                context.drawTextWithShadow(textRenderer, configButton.buttonText(), (int) ((x2 - 92 + 32 - textRenderer.getWidth(configButton.buttonText()) / 2f) / 1.5f), (int) ((propertyY + 16) / 1.5f), 0xFFFFFF);
                 matrices.pop();
             }
             propertyY += 55;
         }
 
-        super.render(matrices, mouseX, mouseY, delta);
+        super.render(context, mouseX, mouseY, delta);
     }
 
     @Override

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/hud/HudPositionsScreen.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/hud/HudPositionsScreen.java
@@ -27,11 +27,6 @@ public class HudPositionsScreen extends Screen {
     }
 
     @Override
-    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
-        super.render(matrices, mouseX, mouseY, delta);
-    }
-
-    @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         if (button == 0) {
             LinkedHashMap<HudElement, ElementInfo> elements = FruitfulUtilities.getInstance().hudManager.elementList;

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/hud/HudRenderer.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/hud/HudRenderer.java
@@ -4,8 +4,7 @@ import dev.kingrabbit.fruitfulutilities.FruitfulUtilities;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.DrawableHelper;
-import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 
@@ -18,7 +17,7 @@ public class HudRenderer implements HudRenderCallback {
     public static final Color BACKGROUND_COLOR = new Color(100, 100, 100, 150);
 
     @Override
-    public void onHudRender(MatrixStack matrices, float tickDelta) {
+    public void onHudRender(DrawContext context, float tickDelta) {
         if (!FruitfulUtilities.getInstance().configManager.enabled()) return;
 
         LinkedHashMap<HudElement, ElementInfo> elements = FruitfulUtilities.getInstance().hudManager.elementList;
@@ -43,7 +42,7 @@ public class HudRenderer implements HudRenderCallback {
                     int lineWidth = line instanceof String ? textRenderer.getWidth((String) line) : (line instanceof OrderedText ? textRenderer.getWidth((OrderedText) line) : textRenderer.getWidth((Text) line));
                     if (lineWidth > maxWidth) maxWidth = lineWidth;
                 }
-                DrawableHelper.fill(matrices, x, y, x + 4 + maxWidth, y + 2 + (textRenderer.fontHeight + 2) * totalLines, BACKGROUND_COLOR.getRGB());
+                context.fill(x, y, x + 4 + maxWidth, y + 2 + (textRenderer.fontHeight + 2) * totalLines, BACKGROUND_COLOR.getRGB());
                 int opacity = 100;
                 for (Object line : lines) {
                     if (line instanceof String stringLine) {
@@ -55,9 +54,11 @@ public class HudRenderer implements HudRenderCallback {
                             }
                             continue;
                         }
-                        DrawableHelper.drawTextWithShadow(matrices, textRenderer, stringLine, x + 2, y + 2, new Color(255, 255, 255, (int) (opacity * 2.55)).getRGB());
-                    } else if (line instanceof OrderedText) DrawableHelper.drawTextWithShadow(matrices, textRenderer, (OrderedText) line, x + 2, y + 2, new Color(255, 255, 255, (int) (opacity * 2.55)).getRGB());
-                    else if (line instanceof Text) DrawableHelper.drawTextWithShadow(matrices, textRenderer, (Text) line, x + 2, y + 2, new Color(255, 255, 255, (int) (opacity * 2.55)).getRGB());
+                        context.drawTextWithShadow(textRenderer, stringLine, x + 2, y + 2, new Color(255, 255, 255, (int) (opacity * 2.55)).getRGB());
+                    } else if (line instanceof OrderedText)
+                        context.drawTextWithShadow(textRenderer, (OrderedText) line, x + 2, y + 2, new Color(255, 255, 255, (int) (opacity * 2.55)).getRGB());
+                    else if (line instanceof Text)
+                        context.drawTextWithShadow(textRenderer, (Text) line, x + 2, y + 2, new Color(255, 255, 255, (int) (opacity * 2.55)).getRGB());
                     y += 2 + textRenderer.fontHeight;
                     opacity = 100;
                 }

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
@@ -91,7 +91,7 @@ public class TickListener implements ClientTickEvents.EndTick {
                     client.player.playSound(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 2.0f, 1.0f);
                 }
                 sendAuctionAlertAt = tick + secondsRemaining * 20;
-            } else if (minutesRemaining <= 25 && auctionWarningReceived || auctionAlertReceived) {
+            } else if (minutesRemaining <= 25 && (auctionWarningReceived || auctionAlertReceived)) {
                 auctionWarningReceived = false;
                 auctionAlertReceived = false;
             }

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
@@ -91,7 +91,7 @@ public class TickListener implements ClientTickEvents.EndTick {
                     client.player.playSound(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 2.0f, 1.0f);
                 }
                 sendAuctionAlertAt = tick + secondsRemaining * 20;
-            } else if (minutesRemaining <= 25 && (auctionWarningReceived || auctionAlertReceived)) {
+            } else if (1 < minutesRemaining && minutesRemaining <= 25 && (auctionWarningReceived || auctionAlertReceived)) {
                 auctionWarningReceived = false;
                 auctionAlertReceived = false;
             }

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/listener/TickListener.java
@@ -91,7 +91,7 @@ public class TickListener implements ClientTickEvents.EndTick {
                     client.player.playSound(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 2.0f, 1.0f);
                 }
                 sendAuctionAlertAt = tick + secondsRemaining * 20;
-            } else if (auctionWarningReceived || auctionAlertReceived) {
+            } else if (minutesRemaining <= 25 && auctionWarningReceived || auctionAlertReceived) {
                 auctionWarningReceived = false;
                 auctionAlertReceived = false;
             }

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/mixin/InGameHudMixin.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/mixin/InGameHudMixin.java
@@ -5,6 +5,7 @@ import dev.kingrabbit.fruitfulutilities.config.ConfigManager;
 import dev.kingrabbit.fruitfulutilities.config.categories.FancyScoreboardCategory;
 import dev.kingrabbit.fruitfulutilities.util.NumberUtils;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
@@ -18,7 +19,7 @@ import java.util.List;
 @Mixin(InGameHud.class)
 public class InGameHudMixin {
 
-    @ModifyArg(method = "renderScoreboardSidebar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/font/TextRenderer;draw(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/text/Text;FFI)I"))
+    @ModifyArg(method = "renderScoreboardSidebar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawText(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/text/Text;IIIZ)I", ordinal = 0))
     public Text fancyScoreboardNumbers(Text text) {
         String textString = text.getString();
         if (!(textString.startsWith("Coins: ") || textString.startsWith("Bank Gold: "))) return text;
@@ -44,10 +45,10 @@ public class InGameHudMixin {
         return configManager.enabled() && configManager.getCategory(FancyScoreboardCategory.class).numbers ? "" : text;
     }
 
-    @Redirect(method = "renderScoreboardSidebar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/font/TextRenderer;draw(Lnet/minecraft/client/util/math/MatrixStack;Ljava/lang/String;FFI)I"))
-    public int removeScoreboardNumbers(TextRenderer instance, MatrixStack matrices, String text, float x, float y, int color) {
+    @Redirect(method = "renderScoreboardSidebar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawText(Lnet/minecraft/client/font/TextRenderer;Ljava/lang/String;IIIZ)I"))
+    public int removeScoreboardNumbers(DrawContext instance, TextRenderer textRenderer, String text, int x, int y, int color, boolean shadow) {
         ConfigManager configManager = FruitfulUtilities.getInstance().configManager;
-        return configManager.enabled() && configManager.getCategory(FancyScoreboardCategory.class).numbers ? 0 : instance.draw(matrices, text, x, y, color);
+        return configManager.enabled() && configManager.getCategory(FancyScoreboardCategory.class).numbers ? 0 : instance.drawText(textRenderer, text, x, y, color, shadow);
     }
 
 }

--- a/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java
+++ b/src/main/java/dev/kingrabbit/fruitfulutilities/pathviewer/PathScreen.java
@@ -9,7 +9,7 @@ import dev.kingrabbit.fruitfulutilities.util.ColorOverlay;
 import dev.kingrabbit.fruitfulutilities.util.NumberUtils;
 import dev.kingrabbit.fruitfulutilities.util.Region;
 import dev.kingrabbit.fruitfulutilities.util.SoundUtils;
-import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.widget.ButtonWidget;
@@ -85,7 +85,7 @@ public class PathScreen extends Screen {
 
     @SuppressWarnings({"IfCanBeSwitch", "SpellCheckingInspection"})
     @Override
-    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
         clearChildren();
         drawnElements.clear();
         tooltip = null;
@@ -95,7 +95,9 @@ public class PathScreen extends Screen {
             yOffset(-64);
         }
 
-        renderBackground(matrices);
+        renderBackground(context);
+
+        MatrixStack matrices = context.getMatrices();
 
         // Path Viewer
         matrices.push();
@@ -104,54 +106,54 @@ public class PathScreen extends Screen {
         
         if (section.equals("beginnings")) {
             JsonObject beginnings = PathManager.paths.get("beginnings");
-            renderUpgrade(matrices, beginnings.getAsJsonObject("faster_melon_spawn_rate"), 1, 1, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("hearth"), 2, 1, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("stronger_front_door"), 3, 1, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("better_jailors"), 4, 1, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("lock_and_key"), 5, 1, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("item_removal_procedures"), 6, 1, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("faster_melon_spawn_rate"), 1, 1, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("hearth"), 2, 1, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("stronger_front_door"), 3, 1, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("better_jailors"), 4, 1, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("lock_and_key"), 5, 1, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("item_removal_procedures"), 6, 1, mouseX, mouseY);
 
-            renderUpgrade(matrices, beginnings.getAsJsonObject("economic_room"), 1, 3, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("faster_coin_generation"), 2, 2, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("better_sell_deals"), 2, 3, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("increased_guard_limit"), 2, 4, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("economic_room"), 1, 3, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("faster_coin_generation"), 2, 2, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("better_sell_deals"), 2, 3, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("increased_guard_limit"), 2, 4, mouseX, mouseY);
             connectUpgrades(1, 3, 2, 2);
             connectUpgrades(1, 3, 2, 3);
             connectUpgrades(1, 3, 2, 4);
 
-            renderUpgrade(matrices, beginnings.getAsJsonObject("private_merchant"), 3, 2, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("personal_greenhouse"), 4, 2, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("private_merchant"), 3, 2, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("personal_greenhouse"), 4, 2, mouseX, mouseY);
             connectUpgrades(3, 2, 4, 2);
 
-            renderUpgrade(matrices, beginnings.getAsJsonObject("castle_ladder"), 3, 3, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("castle_roof"), 4, 3, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("castle_ladder"), 3, 3, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("castle_roof"), 4, 3, mouseX, mouseY);
 
-            renderUpgrade(matrices, beginnings.getAsJsonObject("castle_backyard"), 1, 5, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("castle_basement"), 2, 5, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("urban_start"), 3, 5, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("castle_backyard"), 1, 5, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("castle_basement"), 2, 5, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("urban_start"), 3, 5, mouseX, mouseY);
             connectUpgrades(1, 5, 2, 5);
             connectUpgrades(2, 5, 3, 5);
 
-            renderUpgrade(matrices, beginnings.getAsJsonObject("religion_start"), 3, 4, mouseX, mouseY);
-            renderUpgrade(matrices, beginnings.getAsJsonObject("underground_start"), 4, 4, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("religion_start"), 3, 4, mouseX, mouseY);
+            renderUpgrade(context, beginnings.getAsJsonObject("underground_start"), 4, 4, mouseX, mouseY);
         } else if (section.equals("religion")){
             JsonObject religion = PathManager.paths.get("religion");
-            renderUpgrade(matrices, religion.getAsJsonObject("special_delivery"), 1, 1, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("for_your_convenience"), 2, 1, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("saving_grace"), 3, 1, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("devotion"), 4, 1, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("bountiful_harvest"), 5, 1, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("plentiful_prizes"), 6, 1, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("forgiving_gods"), 7, 1, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("special_delivery"), 1, 1, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("for_your_convenience"), 2, 1, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("saving_grace"), 3, 1, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("devotion"), 4, 1, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("bountiful_harvest"), 5, 1, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("plentiful_prizes"), 6, 1, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("forgiving_gods"), 7, 1, mouseX, mouseY);
 
-            renderUpgrade(matrices, religion.getAsJsonObject("harness_the_spirits"), 2, 4, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("faster_cooking"), 2, 2, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("faster_selling"), 1, 2, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("rise_from_ashes"), 1, 3, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("unconfined_existence"), 4, 3, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("better_farmers"), 1, 5, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("strict_trade_laws"), 1, 6, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("better_return_rates"), 2, 6, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("harness_the_spirits"), 2, 4, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("faster_cooking"), 2, 2, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("faster_selling"), 1, 2, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("rise_from_ashes"), 1, 3, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("unconfined_existence"), 4, 3, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("better_farmers"), 1, 5, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("strict_trade_laws"), 1, 6, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("better_return_rates"), 2, 6, mouseX, mouseY);
             connectUpgrades(2, 2, 2, 4);
             connectUpgrades(1, 2, 2, 4);
             connectUpgrades(1, 3, 2, 4);
@@ -160,12 +162,12 @@ public class PathScreen extends Screen {
             connectUpgrades(1, 6, 2, 4);
             connectUpgrades(2, 4, 2, 6);
 
-            renderUpgrade(matrices, religion.getAsJsonObject("packed_presents"), 3, 2, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("generous_gifts"), 3, 3, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("gold_rush"), 3, 4, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("the_graceful_one"), 5, 2, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("servitude"), 5, 4, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("another_dimension"), 5, 3, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("packed_presents"), 3, 2, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("generous_gifts"), 3, 3, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("gold_rush"), 3, 4, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("the_graceful_one"), 5, 2, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("servitude"), 5, 4, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("another_dimension"), 5, 3, mouseX, mouseY);
             connectUpgrades(3, 2, 4, 3);
             connectUpgrades(3, 3, 4, 3);
             connectUpgrades(3, 4, 4, 3);
@@ -173,13 +175,13 @@ public class PathScreen extends Screen {
             connectUpgrades(4, 3, 5, 3);
             connectUpgrades(4, 3, 5, 4);
 
-            renderUpgrade(matrices, religion.getAsJsonObject("hive_minded_harbingers"), 6, 2, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("complete_clarity"), 7, 2, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("submission"), 7, 3, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("the_greater_good"), 7, 4, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("holy_protection"), 7, 5, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("divine_intervention"), 7, 6, mouseX, mouseY);
-            renderUpgrade(matrices, religion.getAsJsonObject("by_the_power"), 6, 6, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("hive_minded_harbingers"), 6, 2, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("complete_clarity"), 7, 2, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("submission"), 7, 3, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("the_greater_good"), 7, 4, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("holy_protection"), 7, 5, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("divine_intervention"), 7, 6, mouseX, mouseY);
+            renderUpgrade(context, religion.getAsJsonObject("by_the_power"), 6, 6, mouseX, mouseY);
             connectUpgrades(5, 3, 6, 2);
             connectUpgrades(5, 3, 7, 2);
             connectUpgrades(5, 3, 7, 3);
@@ -190,45 +192,45 @@ public class PathScreen extends Screen {
 
         } else if (section.equals("urban")) {
             JsonObject urban = PathManager.paths.get("urban");
-            renderUpgrade(matrices, urban.getAsJsonObject("melon_fertilizer"), 1, 1, mouseX, mouseY);
-            renderUpgrade(matrices, urban.getAsJsonObject("significantly_melonier_melons"), 2, 1, mouseX, mouseY);
-            renderUpgrade(matrices, urban.getAsJsonObject("faster_cooking"), 3, 1, mouseX, mouseY);
-            renderUpgrade(matrices, urban.getAsJsonObject("melon_teleporter"), 4, 1, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("melon_fertilizer"), 1, 1, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("significantly_melonier_melons"), 2, 1, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("faster_cooking"), 3, 1, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("melon_teleporter"), 4, 1, mouseX, mouseY);
 
-            renderUpgrade(matrices, urban.getAsJsonObject("intensive_research"), 1, 3, mouseX, mouseY);
-            renderUpgrade(matrices, urban.getAsJsonObject("melon_harvesting_technology"), 2, 2, mouseX, mouseY);
-            renderUpgrade(matrices, urban.getAsJsonObject("better_return_rates"), 2, 3, mouseX, mouseY);
-            renderUpgrade(matrices, urban.getAsJsonObject("extreme_economy"), 2, 4, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("intensive_research"), 1, 3, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("melon_harvesting_technology"), 2, 2, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("better_return_rates"), 2, 3, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("extreme_economy"), 2, 4, mouseX, mouseY);
             connectUpgrades(1, 3, 2, 2);
             connectUpgrades(1, 3, 2, 3);
             connectUpgrades(1, 3, 2, 4);
 
-            renderUpgrade(matrices, urban.getAsJsonObject("science_start"), 3, 2, mouseX, mouseY);
-            renderUpgrade(matrices, urban.getAsJsonObject("democracy_start"), 3, 3, mouseX, mouseY);
-            renderUpgrade(matrices, urban.getAsJsonObject("true_urban_start"), 3, 4, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("science_start"), 3, 2, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("democracy_start"), 3, 3, mouseX, mouseY);
+            renderUpgrade(context, urban.getAsJsonObject("true_urban_start"), 3, 4, mouseX, mouseY);
         } else if (section.equals("true_urban")) {
             JsonObject trueUrban = PathManager.paths.get("true_urban");
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("a_dollar_a_dime"), 1, 1, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("doubled_city_funding"), 2, 1, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("guaranteed_returns"), 3, 1, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("better_farmers"), 4, 1, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("incredibly_fast_growth"), 1, 2, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("blast_protection"), 2, 2, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("overclock_teleporter"), 3, 2, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("strict_trade_laws"), 4, 2, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("a_dollar_a_dime"), 1, 1, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("doubled_city_funding"), 2, 1, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("guaranteed_returns"), 3, 1, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("better_farmers"), 4, 1, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("incredibly_fast_growth"), 1, 2, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("blast_protection"), 2, 2, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("overclock_teleporter"), 3, 2, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("strict_trade_laws"), 4, 2, mouseX, mouseY);
 
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("bigger_bunker"), 1, 4, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("load_cannons"), 2, 3, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("floating_islands"), 2, 5, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("bigger_bunker"), 1, 4, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("load_cannons"), 2, 3, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("floating_islands"), 2, 5, mouseX, mouseY);
             connectUpgrades(1, 4, 2, 3);
             connectUpgrades(1, 4, 2, 5);
 
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("faster_selling"), 3, 3, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("morale_boost"), 3, 4, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("farming_island"), 3, 5, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("lower_shipping_taxes"), 3, 6, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("even_better_harvesting"), 3, 7, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("island_skylights"), 2, 7, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("faster_selling"), 3, 3, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("morale_boost"), 3, 4, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("farming_island"), 3, 5, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("lower_shipping_taxes"), 3, 6, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("even_better_harvesting"), 3, 7, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("island_skylights"), 2, 7, mouseX, mouseY);
             connectUpgrades(2, 5, 3, 3);
             connectUpgrades(2, 5, 3, 4);
             connectUpgrades(2, 5, 3, 5);
@@ -236,20 +238,20 @@ public class PathScreen extends Screen {
             connectUpgrades(2, 5, 3, 7);
             connectUpgrades(2, 5, 2, 7);
 
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("quality_control"), 4, 4, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("better_filters"), 4, 3, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("quality_control"), 4, 4, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("better_filters"), 4, 3, mouseX, mouseY);
             connectUpgrades(4, 3, 4, 4);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("defender_island"), 4, 5, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("deluxe_sky_farm"), 4, 6, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("defender_island"), 4, 5, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("deluxe_sky_farm"), 4, 6, mouseX, mouseY);
             connectUpgrades(3, 5, 4, 4);
             connectUpgrades(3, 5, 4, 5);
             connectUpgrades(3, 5, 4, 6);
 
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("public_executions"), 5, 3, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("iron_skin"), 5, 4, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("the_grand_finale"), 5, 5, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("projectile_protection"), 5, 6, mouseX, mouseY);
-            renderUpgrade(matrices, trueUrban.getAsJsonObject("pricey_gunpowder"), 5, 7, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("public_executions"), 5, 3, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("iron_skin"), 5, 4, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("the_grand_finale"), 5, 5, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("projectile_protection"), 5, 6, mouseX, mouseY);
+            renderUpgrade(context, trueUrban.getAsJsonObject("pricey_gunpowder"), 5, 7, mouseX, mouseY);
             connectUpgrades(4, 5, 5, 3);
             connectUpgrades(4, 5, 5, 4);
             connectUpgrades(4, 5, 5, 5);
@@ -258,169 +260,169 @@ public class PathScreen extends Screen {
         } else if (section.equals("underground")) {
             JsonObject underground = PathManager.paths.get("underground");
 
-            renderUpgrade(matrices, underground.getAsJsonObject("revoke_weapon_bans"), 1, 1, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("revoke_weapon_bans"), 1, 1, mouseX, mouseY);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("upgrade_town_bm"), 2, 1, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("quicker_trading"), 3, 1, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("upgrade_town_bm"), 2, 1, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("quicker_trading"), 3, 1, mouseX, mouseY);
             connectUpgrades(2, 1, 3, 1);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("lucky_day"), 1, 2, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("farming_rally"), 2, 2, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("faster_cooking"), 3, 2, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("lucky_day"), 1, 2, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("farming_rally"), 2, 2, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("faster_cooking"), 3, 2, mouseX, mouseY);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("upgrade_town_armory"), 2, 3, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("advanced_weaponry"), 1, 3, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("public_executions"), 1, 4, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("increased_blast_resistance"), 1, 5, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("upgrade_town_armory"), 2, 3, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("advanced_weaponry"), 1, 3, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("public_executions"), 1, 4, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("increased_blast_resistance"), 1, 5, mouseX, mouseY);
             connectUpgrades(1, 3, 2, 3);
             connectUpgrades(1, 4, 2, 3);
             connectUpgrades(1, 5, 2, 3);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("better_bankers"), 2, 4, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("better_bankers"), 2, 4, mouseX, mouseY);
             connectUpgrades(2, 3, 2, 4);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("faster_selling"), 3, 3, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("rapid_reload"), 3, 4, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("better_return_rates"), 3, 5, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("faster_selling"), 3, 3, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("rapid_reload"), 3, 4, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("better_return_rates"), 3, 5, mouseX, mouseY);
             connectUpgrades(2, 3, 3, 3);
             connectUpgrades(2, 3, 3, 4);
             connectUpgrades(2, 3, 3, 5);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("upgrade_town_center"), 4, 3, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("quicker_sprouting"), 4, 1, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("fertile_soil"), 5, 1, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("upgrade_town_center"), 4, 3, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("quicker_sprouting"), 4, 1, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("fertile_soil"), 5, 1, mouseX, mouseY);
             connectUpgrades(4, 1, 4, 3);
             connectUpgrades(4, 3, 5, 1);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("golden_extractors"), 6, 1, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("market_manipulation"), 6, 2, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("projectile_proofing"), 6, 3, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("light_based_growth_spurts"), 6, 4, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("golden_extractors"), 6, 1, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("market_manipulation"), 6, 2, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("projectile_proofing"), 6, 3, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("light_based_growth_spurts"), 6, 4, mouseX, mouseY);
             connectUpgrades(4, 3, 6, 1);
             connectUpgrades(4, 3, 6, 2);
             connectUpgrades(4, 3, 6, 3);
             connectUpgrades(4, 3, 6, 4);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("upgrade_town_depths"), 4, 6, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("richer_metals"), 3, 7, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("grenade_tech_breakthrough"), 4, 7, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("doubled_city_funding"), 5, 7, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("depths_start"), 3, 6, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("upgrade_town_depths"), 4, 6, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("richer_metals"), 3, 7, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("grenade_tech_breakthrough"), 4, 7, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("doubled_city_funding"), 5, 7, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("depths_start"), 3, 6, mouseX, mouseY);
             connectUpgrades(4, 3, 4, 6);
             connectUpgrades(3, 7, 4, 6);
             connectUpgrades(4, 6, 4, 7);
             connectUpgrades(4, 6, 5, 7);
             connectUpgrades(3, 6, 4, 6);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("upgrade_town_farm"), 7, 7, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("what_shines_bright"), 6, 7, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("guaranteed_returns"), 8, 7, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("upgrade_town_farm"), 7, 7, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("what_shines_bright"), 6, 7, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("guaranteed_returns"), 8, 7, mouseX, mouseY);
             connectUpgrades(4, 3, 7, 7);
             connectUpgrades(6, 7, 7, 7);
             connectUpgrades(7, 7, 8, 7);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("farming_reservations"), 6, 8, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("extra_fertilizer"), 7, 8, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("melon_generators"), 8, 8, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("farming_reservations"), 6, 8, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("extra_fertilizer"), 7, 8, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("melon_generators"), 8, 8, mouseX, mouseY);
             connectUpgrades(6, 8, 7, 7);
             connectUpgrades(7, 7, 7, 8);
             connectUpgrades(7, 7, 8, 8);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("upgrade_town_second_wall"), 6, 5, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("upgrade_town_teleporter"), 7, 4, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("currency_exchange"), 7, 6, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("upgrade_town_second_wall"), 6, 5, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("upgrade_town_teleporter"), 7, 4, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("currency_exchange"), 7, 6, mouseX, mouseY);
             connectUpgrades(4, 3, 6, 5);
             connectUpgrades(6, 5, 7, 4);
             connectUpgrades(6, 5, 7, 6);
 
-            renderUpgrade(matrices, underground.getAsJsonObject("upgrade_town_raid"), 7, 5, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("cutting_through"), 8, 4, mouseX, mouseY);
-            renderUpgrade(matrices, underground.getAsJsonObject("raid_start"), 8, 6, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("upgrade_town_raid"), 7, 5, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("cutting_through"), 8, 4, mouseX, mouseY);
+            renderUpgrade(context, underground.getAsJsonObject("raid_start"), 8, 6, mouseX, mouseY);
             connectUpgrades(6, 5, 7, 5);
             connectUpgrades(7, 5, 8, 4);
             connectUpgrades(7, 5, 8, 6);
         } else if (section.equals("raid")) {
             JsonObject raid = PathManager.paths.get("raid");
 
-            renderUpgrade(matrices, raid.getAsJsonObject("standard_issue_forges"), 1, 1, mouseX, mouseY);
-            renderUpgrade(matrices, raid.getAsJsonObject("basic_armory"), 2, 1, mouseX, mouseY);
-            renderUpgrade(matrices, raid.getAsJsonObject("grenade_stockpiles"), 3, 1, mouseX, mouseY);
-            renderUpgrade(matrices, raid.getAsJsonObject("power_through"), 4, 1, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("standard_issue_forges"), 1, 1, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("basic_armory"), 2, 1, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("grenade_stockpiles"), 3, 1, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("power_through"), 4, 1, mouseX, mouseY);
 
-            renderUpgrade(matrices, raid.getAsJsonObject("thorough_defense"), 1, 2, mouseX, mouseY);
-            renderUpgrade(matrices, raid.getAsJsonObject("stronger_blades"), 2, 2, mouseX, mouseY);
-            renderUpgrade(matrices, raid.getAsJsonObject("gemstone_blades"), 3, 2, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("thorough_defense"), 1, 2, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("stronger_blades"), 2, 2, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("gemstone_blades"), 3, 2, mouseX, mouseY);
 
-            renderUpgrade(matrices, raid.getAsJsonObject("diamond_forges"), 1, 3, mouseX, mouseY);
-            renderUpgrade(matrices, raid.getAsJsonObject("the_perfect_weapons"), 2, 3, mouseX, mouseY);
-            renderUpgrade(matrices, raid.getAsJsonObject("impenetrable_defenses"), 3, 3, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("diamond_forges"), 1, 3, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("the_perfect_weapons"), 2, 3, mouseX, mouseY);
+            renderUpgrade(context, raid.getAsJsonObject("impenetrable_defenses"), 3, 3, mouseX, mouseY);
         } else if (section.equals("depths")) {
             JsonObject depths = PathManager.paths.get("depths");
 
-            renderUpgrade(matrices, depths.getAsJsonObject("warrant_funding"), 2, 1, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("farmland_acquisition"), 3, 1, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("even_quicker_trading"), 4, 1, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("luckier_day"), 2, 2, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("value_duplication"), 3, 2, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("double_duplication"), 4, 2, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("warrant_funding"), 2, 1, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("farmland_acquisition"), 3, 1, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("even_quicker_trading"), 4, 1, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("luckier_day"), 2, 2, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("value_duplication"), 3, 2, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("double_duplication"), 4, 2, mouseX, mouseY);
             connectUpgrades(3, 2, 4, 2);
-            renderUpgrade(matrices, depths.getAsJsonObject("better_negotiations"), 2, 3, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("triple_city_funding"), 3, 3, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("dual_polishing_measures"), 4, 3, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("better_negotiations"), 2, 3, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("triple_city_funding"), 3, 3, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("dual_polishing_measures"), 4, 3, mouseX, mouseY);
 
-            renderUpgrade(matrices, depths.getAsJsonObject("upgrade_town_east"), 6, 2, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("blacklight_photosynthesis"), 7, 1, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("farmland_expansion"), 8, 1, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("greed_is_good"), 9, 1, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("exponential_scaling"), 7, 2, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("quadruple_city_funding"), 8, 2, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("expert_economists"), 9, 2, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("underground_trade_routes"), 7, 3, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("extrinsic_value"), 8, 3, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("upgrade_town_east"), 6, 2, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("blacklight_photosynthesis"), 7, 1, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("farmland_expansion"), 8, 1, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("greed_is_good"), 9, 1, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("exponential_scaling"), 7, 2, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("quadruple_city_funding"), 8, 2, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("expert_economists"), 9, 2, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("underground_trade_routes"), 7, 3, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("extrinsic_value"), 8, 3, mouseX, mouseY);
 
-            renderUpgrade(matrices, depths.getAsJsonObject("upgrade_town_north"), 1, 6, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("melon_to_melon_ratio"), 2, 5, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("insider_knowledge"), 3, 5, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("value_incrementation"), 4, 5, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("the_house_always_wins"), 2, 6, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("quintuple_city_funding"), 3, 6, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("multiply_demand"), 4, 6, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("quantum_fluctuations"), 2, 7, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("farming_permits"), 3, 7, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("upgrade_town_north"), 1, 6, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("melon_to_melon_ratio"), 2, 5, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("insider_knowledge"), 3, 5, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("value_incrementation"), 4, 5, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("the_house_always_wins"), 2, 6, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("quintuple_city_funding"), 3, 6, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("multiply_demand"), 4, 6, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("quantum_fluctuations"), 2, 7, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("farming_permits"), 3, 7, mouseX, mouseY);
 
-            renderUpgrade(matrices, depths.getAsJsonObject("upgrade_town_south"), 6, 6, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("tri_polishing_process"), 7, 5, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("sextuple_city_funding"), 8, 5, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("repeated_multiplication"), 7, 6, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("farmland_reclamation"), 8, 6, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("the_foundry"), 7, 7, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("perfect_profits"), 8, 7, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("we_need_to_go_deeper"), 10, 4, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("final_funding"), 10, 5, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("upgrade_town_south"), 6, 6, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("tri_polishing_process"), 7, 5, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("sextuple_city_funding"), 8, 5, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("repeated_multiplication"), 7, 6, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("farmland_reclamation"), 8, 6, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("the_foundry"), 7, 7, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("perfect_profits"), 8, 7, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("we_need_to_go_deeper"), 10, 4, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("final_funding"), 10, 5, mouseX, mouseY);
             connectUpgrades(10, 4, 10, 5);
 
-            renderUpgrade(matrices, depths.getAsJsonObject("better_farmers"), 11, 3, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("a_little_richer"), 12, 3, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("septuple_city_funding"), 13, 3, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("fullest_farmland"), 11, 4, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("octuple_city_funding"), 12, 4, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("true_value"), 13, 4, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("ultimate_exponential"), 11, 5, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("flawless_extraction"), 12, 5, mouseX, mouseY);
-            renderUpgrade(matrices, depths.getAsJsonObject("one_billion_gold"), 13, 5, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("better_farmers"), 11, 3, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("a_little_richer"), 12, 3, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("septuple_city_funding"), 13, 3, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("fullest_farmland"), 11, 4, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("octuple_city_funding"), 12, 4, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("true_value"), 13, 4, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("ultimate_exponential"), 11, 5, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("flawless_extraction"), 12, 5, mouseX, mouseY);
+            renderUpgrade(context, depths.getAsJsonObject("one_billion_gold"), 13, 5, mouseX, mouseY);
         }
 
         matrices.pop();
 
         // UI
-        DrawableHelper.fill(matrices, 0, 0, width / 5, height, PRIMARY);
-        DrawableHelper.fill(matrices, width / 5, 0, width / 5 + 6, height, SECONDARY);
+        context.fill(0, 0, width / 5, height, PRIMARY);
+        context.fill(width / 5, 0, width / 5 + 6, height, SECONDARY);
 
-        DrawableHelper.drawCenteredTextWithShadow(matrices, textRenderer, "Path Viewer", width / 10, 20, HEADER_COLOR);
+        context.drawCenteredTextWithShadow(textRenderer, "Path Viewer", width / 10, 20, HEADER_COLOR);
         int y = 40;
         if (!selectedElement.containsKey(section)) {
             for (OrderedText line : textRenderer.wrapLines(StringVisitable.plain("Click on an upgrade to view information about it."), width / 5 - 20)) {
-                DrawableHelper.drawTextWithShadow(matrices, textRenderer, line, 10, y, 0xFFFFFF);
+                context.drawTextWithShadow(textRenderer, line, 10, y, 0xFFFFFF);
                 y += textRenderer.fontHeight + 2;
             }
         } else {
@@ -433,7 +435,7 @@ public class PathScreen extends Screen {
                             "§6Price: §f" + NumberUtils.toFancyNumber(price) + " " + Currency.valueOf(_selectedElement.get("currency").getAsString().toUpperCase()).format(price) + "\n" +
                             "§6Location: §f" + _selectedElement.get("location").getAsString().replaceAll(",", ", ")
             ), width / 5 - 20)) {
-                DrawableHelper.drawTextWithShadow(matrices, textRenderer, line, 10, y, 0xFFFFFF);
+                context.drawTextWithShadow(textRenderer, line, 10, y, 0xFFFFFF);
                 y += textRenderer.fontHeight + 2;
             }
 
@@ -459,8 +461,8 @@ public class PathScreen extends Screen {
 
             addSelectableChild(track);
             addSelectableChild(unlock);
-            track.render(matrices, mouseX, mouseY, delta);
-            unlock.render(matrices, mouseX, mouseY, delta);
+            track.render(context, mouseX, mouseY, delta);
+            unlock.render(context, mouseX, mouseY, delta);
 
             y += 60;
             if (!sameLine) y += 30;
@@ -468,14 +470,14 @@ public class PathScreen extends Screen {
 
         y += 20;
 
-        DrawableHelper.drawCenteredTextWithShadow(matrices, textRenderer, "Tracked Upgrades", width / 10, y, HEADER_COLOR);
+        context.drawCenteredTextWithShadow(textRenderer, "Tracked Upgrades", width / 10, y, HEADER_COLOR);
         y += 20;
 
         List<JsonObject> allTracked = PathManager.allTracked();
 
         if (allTracked.isEmpty()) {
             for (OrderedText line : textRenderer.wrapLines(StringVisitable.plain("Track an upgrade to view its waypoint and track your progress towards it."), width / 5 - 20)) {
-                DrawableHelper.drawTextWithShadow(matrices, textRenderer, line, 10, y, 0xFFFFFF);
+                context.drawTextWithShadow(textRenderer, line, 10, y, 0xFFFFFF);
                 y += textRenderer.fontHeight + 2;
             }
         } else {
@@ -492,7 +494,7 @@ public class PathScreen extends Screen {
                 }
             }
             for (OrderedText line : textRenderer.wrapLines(StringVisitable.plain(information.toString()), width / 5 - 20)) {
-                DrawableHelper.drawTextWithShadow(matrices, textRenderer, line, 10, y, 0xFFFFFF);
+                context.drawTextWithShadow(textRenderer, line, 10, y, 0xFFFFFF);
                 y += textRenderer.fontHeight + 2;
             }
 
@@ -502,7 +504,7 @@ public class PathScreen extends Screen {
             xOffset(width / 5f - 64 + 32 * 1.5f);
             yOffset(-64);
             zoom(1);
-        }).dimensions(width - 103, height - 100, 98, 20).tooltip(Tooltip.of(Text.of("Reset the window's current offset and zoom. (R)"))).build()).render(matrices, mouseX, mouseY, delta);
+        }).dimensions(width - 103, height - 100, 98, 20).tooltip(Tooltip.of(Text.of("Reset the window's current offset and zoom. (R)"))).build()).render(context, mouseX, mouseY, delta);
 
         addSelectableChild(ButtonWidget.builder(Text.of("Track All"), button -> {
             for (JsonElement _pathUpgrade : PathManager.paths.get(section).asMap().values()) {
@@ -511,15 +513,15 @@ public class PathScreen extends Screen {
                     PathManager.tracking.add(pathUpgrade);
                 }
             }
-        }).dimensions(width - 103, height - 75, 98, 20).tooltip(Tooltip.of(Text.of("Track all upgrades in the selected path."))).build()).render(matrices, mouseX, mouseY, delta);
+        }).dimensions(width - 103, height - 75, 98, 20).tooltip(Tooltip.of(Text.of("Track all upgrades in the selected path."))).build()).render(context, mouseX, mouseY, delta);
 
         addSelectableChild(ButtonWidget.builder(Text.of("Untrack All"),
                 button -> PathManager.tracking.removeIf(jsonObject -> PathManager.paths.get(section).asMap().containsValue(jsonObject))
-        ).dimensions(width - 103, height - 50, 98, 20).tooltip(Tooltip.of(Text.of("Untrack all upgrades in the selected path."))).build()).render(matrices, mouseX, mouseY, delta);
+        ).dimensions(width - 103, height - 50, 98, 20).tooltip(Tooltip.of(Text.of("Untrack all upgrades in the selected path."))).build()).render(context, mouseX, mouseY, delta);
 
         addSelectableChild(ButtonWidget.builder(Text.of("Clear Cache"),
                 button -> PathManager.clearCache()
-        ).dimensions(width - 103, height - 25, 98, 20).tooltip(Tooltip.of(Text.of("Reculates the state and cost of upgrades."))).build()).render(matrices, mouseX, mouseY, delta);
+        ).dimensions(width - 103, height - 25, 98, 20).tooltip(Tooltip.of(Text.of("Reculates the state and cost of upgrades."))).build()).render(context, mouseX, mouseY, delta);
 
         // Item tabs
         matrices.push();
@@ -529,7 +531,7 @@ public class PathScreen extends Screen {
         for (String _section : section_order) {
             if (sections.containsKey(_section)) {
                 ItemGroup icon = section_icons.get(_section);
-                renderTabIcon(matrices, icon, section.equals(_section), tabX, tabY);
+                renderTabIcon(context, icon, section.equals(_section), tabX, tabY);
                 if (tabX <= mouseX / 1.5f && mouseX / 1.5f <= tabX + 32 &&
                         tabY <= mouseY / 1.5f && mouseY / 1.5f <= tabY + 26) {
                     tooltip = Collections.singletonList(icon.getDisplayName().asOrderedText());
@@ -541,18 +543,17 @@ public class PathScreen extends Screen {
 
         // Tooltip
         if (tooltip != null) {
-            renderOrderedTooltip(matrices, tooltip, mouseX, mouseY);
+            context.drawOrderedTooltip(textRenderer, tooltip, mouseX, mouseY);
         }
     }
 
-    public void renderTabIcon(MatrixStack matrices, ItemGroup group, boolean selected, int tabX, int tabY) {
-        RenderSystem.setShaderTexture(0, TAB_TEXTURE);
-        DrawableHelper.drawTexture(matrices, tabX, tabY, 0, selected ? 26 : 0, 32, 26, 32, 52);
+    public void renderTabIcon(DrawContext context, ItemGroup group, boolean selected, int tabX, int tabY) {
+        MatrixStack matrices = context.getMatrices();
+        context.drawTexture(TAB_TEXTURE, tabX, tabY, 0, selected ? 26 : 0, 32, 26, 32, 52);
         matrices.push();
         matrices.translate(0.0f, 0.0f, 100.0f);
         ItemStack itemStack = group.getIcon();
-        this.itemRenderer.renderInGuiWithOverrides(matrices, itemStack, tabX += 8, tabY += 5);
-        this.itemRenderer.renderGuiItemOverlay(matrices, this.textRenderer, itemStack, tabX, tabY);
+        context.drawItem(itemStack, tabX + 8, tabY + 5);
         matrices.pop();
     }
 
@@ -617,7 +618,7 @@ public class PathScreen extends Screen {
         GlStateManager._depthMask(true);
     }
 
-    public void renderUpgrade(MatrixStack matrices, JsonObject upgrade, float x, float y, int mouseX, int mouseY) {
+    public void renderUpgrade(DrawContext context, JsonObject upgrade, float x, float y, int mouseX, int mouseY) {
         if (upgrade == null) {
             String errorMessage = "Not rendering upgrade at " + x + ", " + y + " on path " + section + " as it is null.";
             if (!sentErrors.contains(errorMessage)) {
@@ -626,6 +627,8 @@ public class PathScreen extends Screen {
             }
             return;
         }
+
+        MatrixStack matrices = context.getMatrices();
 
         float _xOffset = xOffset();
         float _yOffset = yOffset();
@@ -651,12 +654,9 @@ public class PathScreen extends Screen {
         if (selected) color = ColorOverlay.overlayColors(color, new Color(255, 255, 150), 0.35f);
         if (hovered) color = ColorOverlay.overlayColors(color, new Color(150, 150, 150), 0.35f);
 
-        RenderSystem.setShaderTexture(0, major ? MAJOR_PATH_ICON : PATH_ICON);
-        RenderSystem.setShaderColor(color.getRed() / 255f, color.getGreen() / 255f, color.getBlue() / 255f, color.getAlpha() / 255f);
-
-        DrawableHelper.drawTexture(matrices, (int) (_xOffset + x), (int) (_yOffset + y), 0, 0, 0, 32, 32, 32, 32);
-
-        RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
+        context.setShaderColor(color.getRed() / 255f, color.getGreen() / 255f, color.getBlue() / 255f, color.getAlpha() / 255f);
+        context.drawTexture(major ? MAJOR_PATH_ICON : PATH_ICON, (int) (_xOffset + x), (int) (_yOffset + y), 0, 0, 0, 32, 32, 32, 32);
+        context.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
 
         if (hovered) {
             if (mouseX < width / 5 + 6) return;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,6 +26,6 @@
   "depends": {
     "fabricloader": ">=0.14.21",
     "fabric": "*",
-    "minecraft": "1.19.4"
+    "minecraft": "1.20.1"
   }
 }


### PR DESCRIPTION
Updated FruitfulUtilities to 1.20.1 to allow players to continue using the mod when DiamondFire updates.

# Testing Checklist

- [x] General Features
  - [x] Enabling / Disabling the mod
  - [x] Plot detection
- [x] GUI Locations
  - [x] Editing GUI locations
  - [x] Resetting GUI locations
- [x] Path Viewer
  - [x] Rendering
  - [x] Tracking upgrades
  - [x] Unlocking all paths (via command)
  - [x] Moving around / zooming
  - [x] Buttons on bottom right
  - [x] Upgrade detection
- [x] Upgrade beacons
  - [x] All combinations of beacons and highlights enabled/disabled
  - [x] Hide if locked
  - [x] Hide if unlocked
- [x] Fancy Scoreboard
  - [x] Balance Commas
  - [x] Hide Numbers
- [x] Code Hider
  - [x] With Sodium (water and faces inside blocks may still render)
  - [x] Without Sodium
- [x] Searching Tracker
  - [x] HUD
    - [x] Fades before disappearing
    - [x] Hide if no drops
  - [x] Chat
- [x] Message Hider
  - [x] Works
- [x] Auction Timer
  - [x] Melon King enabled, Auction Timer enabled
  - [x] Melon King disabled, Auction Timer enabled